### PR TITLE
Update sobek_frn_me.qml

### DIFF
--- a/layouts/sobek_ennazerty_me.qml
+++ b/layouts/sobek_ennazerty_me.qml
@@ -1,4 +1,5 @@
 // Copyright (c) 2019, Adel Noureddine. All rights reserved.
+// Contribution by Simon Descarpentries, 2026-05.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -131,7 +132,7 @@ KeyboardLayout {
         }
         CharacterKey {
             caption: "e"; captionShifted: "E"; symView: "3"; symView2: "$"
-            accents: "èeéêë~"; accentsShifted: "ÈEÉÊË~"
+            accents: "~eèéêë"; accentsShifted: "~EÈÉÊË"
             nativeAccents: "èéêë"; nativeAccentsShifted: "ÈÉÊË";
             Text {
                 text: showSymbolsOnKey("~");
@@ -150,7 +151,7 @@ KeyboardLayout {
                 }
             }
         }
-        CharacterKey { caption: "t"; captionShifted: "T"; symView: "5"; symView2: "₹"; accents: "tþ["; accentsShifted: "TÞ[";
+        CharacterKey { caption: "t"; captionShifted: "T"; symView: "5"; symView2: "₹"; accents: "[tþ"; accentsShifted: "[TÞ";
             Text {
                 text: showSymbolsOnKey("[");
                 color: Theme.highlightColor;
@@ -159,7 +160,7 @@ KeyboardLayout {
                 }
             }
         }
-        CharacterKey { caption: "y"; captionShifted: "Y"; symView: "6"; symView2: "%"; accents: "ýy¥]"; accentsShifted: "ÝY¥]";
+        CharacterKey { caption: "y"; captionShifted: "Y"; symView: "6"; symView2: "%"; accents: "ýy]¥"; accentsShifted: "ÝY]¥";
             Text {
                 text: showSymbolsOnKey("]");
                 color: Theme.highlightColor;
@@ -170,7 +171,7 @@ KeyboardLayout {
         }
         CharacterKey {
             caption: "u"; captionShifted: "U"; symView: "7"; symView2: "<"
-            accents: "üûuùú<"; accentsShifted: "ÜÛUÙÚ<"
+            accents: "üû<uùú"; accentsShifted: "ÜÛ«UÙÚ"
             nativeAccents: "ûùü"; nativeAccentsShifted: "ÛÙÜ";
             Text {
                 text: showSymbolsOnKey("<");
@@ -182,7 +183,7 @@ KeyboardLayout {
         }
         CharacterKey {
             caption: "i"; captionShifted: "I"; symView: "8"; symView2: ">"
-            accents: "íìîiï>"; accentsShifted: "ÍÌÎIÏ>"
+            accents: "íìîi>iï"; accentsShifted: "ÍÌÎI»Ï"
             nativeAccents: "îï"; nativeAccentsShifted: "ÎÏ";
             Text {
                 text: showSymbolsOnKey(">");
@@ -194,7 +195,7 @@ KeyboardLayout {
         }
         CharacterKey {
             caption: "o"; captionShifted: "O"; symView: "9"; symView2: "["
-            accents: "øöòóôoœ{"; accentsShifted: "ØÖÒÓÔOŒ{"
+            accents: "øöòóôo{œ"; accentsShifted: "ØÖÒÓÔO{Œ"
             nativeAccents: "ô"; nativeAccentsShifted: "Ô";
             Text {
                 text: showSymbolsOnKey("{");
@@ -204,7 +205,7 @@ KeyboardLayout {
                 }
             }
         }
-        CharacterKey { caption: "p"; captionShifted: "P"; symView: "0"; symView2: "]"; accents: "}"; accentsShifted: "}";
+        CharacterKey { caption: "p"; captionShifted: "P"; symView: "0"; symView2: "]"; accents: "}p§"; accentsShifted: "}P§";
             Text {
                 text: showSymbolsOnKey("}");
                 color: Theme.highlightColor;
@@ -225,7 +226,7 @@ KeyboardLayout {
                 }
             }
         }
-        CharacterKey { caption: "s"; captionShifted: "S"; symView: "#"; symView2: "^"; accents: "#"; accentsShifted: "#";
+        CharacterKey { caption: "s"; captionShifted: "S"; symView: "#"; symView2: "^"; accents: "#s$"; accentsShifted: "#S$";
             Text {
                 text: showSymbolsOnKey("#");
                 color: Theme.highlightColor;
@@ -297,7 +298,7 @@ KeyboardLayout {
                 }
             }
         }
-        CharacterKey { caption: "m"; captionShifted: "M"; symView: "?"; symView2: "¿"; accents: "^"; accentsShifted: "^";
+        CharacterKey { caption: "m"; captionShifted: "M"; symView: "?"; symView2: "¿"; accents: "^mµ"; accentsShifted: "^Mµ";
             Text {
                 text: showSymbolsOnKey("^");
                 color: Theme.highlightColor;
@@ -373,6 +374,14 @@ KeyboardLayout {
             implicitWidth: punctuationKeyWidth
             fixedWidth: !splitActive
             symView: ":"; symView2: "‰";
+            accents: "`"; accentsShifted: "`";
+            Text {
+                text: showSymbolsOnKey("`");
+                color: Theme.highlightColor;
+                anchors {
+                    horizontalCenter: parent.horizontalCenter
+                }
+            }
         }
 
         BackspaceKey {}

--- a/layouts/sobek_ennazerty_me.qml
+++ b/layouts/sobek_ennazerty_me.qml
@@ -143,7 +143,7 @@ KeyboardLayout {
         }
         CharacterKey { caption: "r"; captionShifted: "R"; symView: "4"; symView2: "¥"; accents: "|"; accentsShifted: "|";
             Text {
-                text: showSymbolsOnKey("~");
+                text: showSymbolsOnKey("|");
                 color: Theme.highlightColor;
                 anchors {
                     horizontalCenter: parent.horizontalCenter

--- a/layouts/sobek_frn_me.qml
+++ b/layouts/sobek_frn_me.qml
@@ -110,7 +110,7 @@ KeyboardLayout {
     KeyboardRow {
         CharacterKey {
             caption: "a"; captionShifted: "A"; symView: "1"; symView2: "€"
-            accents: "aâàæäáãå%"; accentsShifted: "AÂÀÆÄÁÃÅ%"
+            accents: "%aàâæäáãå"; accentsShifted: "%AÀÂÆÄÁÃÅ"
             nativeAccents: "àâ"; nativeAccentsShifted: "ÀÂ";
             Text {
                 text: showSymbolsOnKey("%");
@@ -131,7 +131,7 @@ KeyboardLayout {
         }
         CharacterKey {
             caption: "e"; captionShifted: "E"; symView: "3"; symView2: "$"
-            accents: "èeéêë~"; accentsShifted: "ÈEÉÊË~"
+            accents: "~eéèêë"; accentsShifted: "~EÉÈÊË"
             nativeAccents: "èéêë"; nativeAccentsShifted: "ÈÉÊË";
             Text {
                 text: showSymbolsOnKey("~");
@@ -143,14 +143,14 @@ KeyboardLayout {
         }
         CharacterKey { caption: "r"; captionShifted: "R"; symView: "4"; symView2: "¥"; accents: "|"; accentsShifted: "|";
             Text {
-                text: showSymbolsOnKey("~");
+                text: showSymbolsOnKey("|");
                 color: Theme.highlightColor;
                 anchors {
                     horizontalCenter: parent.horizontalCenter
                 }
             }
         }
-        CharacterKey { caption: "t"; captionShifted: "T"; symView: "5"; symView2: "₹"; accents: "tþ["; accentsShifted: "TÞ[";
+        CharacterKey { caption: "t"; captionShifted: "T"; symView: "5"; symView2: "₹"; accents: "[tþ"; accentsShifted: "[TÞ";
             Text {
                 text: showSymbolsOnKey("[");
                 color: Theme.highlightColor;
@@ -159,7 +159,7 @@ KeyboardLayout {
                 }
             }
         }
-        CharacterKey { caption: "y"; captionShifted: "Y"; symView: "6"; symView2: "%"; accents: "ýy¥]"; accentsShifted: "ÝY¥]";
+        CharacterKey { caption: "y"; captionShifted: "Y"; symView: "6"; symView2: "%"; accents: "]yý¥"; accentsShifted: "]YÝ¥";
             Text {
                 text: showSymbolsOnKey("]");
                 color: Theme.highlightColor;
@@ -170,7 +170,7 @@ KeyboardLayout {
         }
         CharacterKey {
             caption: "u"; captionShifted: "U"; symView: "7"; symView2: "<"
-            accents: "üûuùú<"; accentsShifted: "ÜÛUÙÚ<"
+            accents: "<uùúûü"; accentsShifted: "<UÙÚÛÜ"
             nativeAccents: "ûùü"; nativeAccentsShifted: "ÛÙÜ";
             Text {
                 text: showSymbolsOnKey("<");
@@ -182,7 +182,7 @@ KeyboardLayout {
         }
         CharacterKey {
             caption: "i"; captionShifted: "I"; symView: "8"; symView2: ">"
-            accents: "íìîiï>"; accentsShifted: "ÍÌÎIÏ>"
+            accents: ">iïîíì"; accentsShifted: ">IÏÌÎÍ"
             nativeAccents: "îï"; nativeAccentsShifted: "ÎÏ";
             Text {
                 text: showSymbolsOnKey(">");
@@ -194,7 +194,7 @@ KeyboardLayout {
         }
         CharacterKey {
             caption: "o"; captionShifted: "O"; symView: "9"; symView2: "["
-            accents: "øöòóôoœ{"; accentsShifted: "ØÖÒÓÔOŒ{"
+            accents: "øöòóô{oœ"; accentsShifted: "ØÖÒÓÔ{OŒ"
             nativeAccents: "ô"; nativeAccentsShifted: "Ô";
             Text {
                 text: showSymbolsOnKey("{");
@@ -234,7 +234,7 @@ KeyboardLayout {
                 }
             }
         }
-        CharacterKey { caption: "d"; captionShifted: "D"; symView: "+"; symView2: "|"; accents: "dð&"; accentsShifted: "DÐ&";
+        CharacterKey { caption: "d"; captionShifted: "D"; symView: "+"; symView2: "|"; accents: "&dð"; accentsShifted: "&DÐ";
             Text {
                 text: showSymbolsOnKey("&");
                 color: Theme.highlightColor;
@@ -331,7 +331,7 @@ KeyboardLayout {
                 }
             }
         }
-        CharacterKey { caption: "c"; captionShifted: "C"; symView: "/"; symView2: "÷"; accents: "cç\""; accentsShifted: "CÇ\"";
+        CharacterKey { caption: "c"; captionShifted: "C"; symView: "/"; symView2: "÷"; accents: "\"cç"; accentsShifted: "\"CÇ";
             Text {
                 text: showSymbolsOnKey("\"");
                 color: Theme.highlightColor;
@@ -358,7 +358,7 @@ KeyboardLayout {
                 }
             }
         }
-        CharacterKey { caption: "n"; captionShifted: "N"; symView: ";"; symView2: "„"; accents: "nñ/"; accentsShifted: "NÑ/";
+        CharacterKey { caption: "n"; captionShifted: "N"; symView: ";"; symView2: "„"; accents: "/nñ"; accentsShifted: "/NÑ";
             Text {
                 text: showSymbolsOnKey("/");
                 color: Theme.highlightColor;

--- a/layouts/sobek_frn_me.qml
+++ b/layouts/sobek_frn_me.qml
@@ -1,4 +1,5 @@
 // Copyright (c) 2019, Adel Noureddine. All rights reserved.
+// Contribution by Simon Descarpentries, 2026-05.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -170,7 +171,7 @@ KeyboardLayout {
         }
         CharacterKey {
             caption: "u"; captionShifted: "U"; symView: "7"; symView2: "<"
-            accents: "<uùúûü"; accentsShifted: "<UÙÚÛÜ"
+            accents: "<uµùúûü"; accentsShifted: "«UµÙÚÛÜ"
             nativeAccents: "ûùü"; nativeAccentsShifted: "ÛÙÜ";
             Text {
                 text: showSymbolsOnKey("<");
@@ -182,7 +183,7 @@ KeyboardLayout {
         }
         CharacterKey {
             caption: "i"; captionShifted: "I"; symView: "8"; symView2: ">"
-            accents: ">iïîíì"; accentsShifted: ">IÏÌÎÍ"
+            accents: ">iïîíì"; accentsShifted: "»IÏÌÎÍ"
             nativeAccents: "îï"; nativeAccentsShifted: "ÎÏ";
             Text {
                 text: showSymbolsOnKey(">");
@@ -204,7 +205,7 @@ KeyboardLayout {
                 }
             }
         }
-        CharacterKey { caption: "p"; captionShifted: "P"; symView: "0"; symView2: "]"; accents: "}"; accentsShifted: "}";
+        CharacterKey { caption: "p"; captionShifted: "P"; symView: "0"; symView2: "]"; accents: "}p§"; accentsShifted: "}P§";
             Text {
                 text: showSymbolsOnKey("}");
                 color: Theme.highlightColor;
@@ -225,7 +226,7 @@ KeyboardLayout {
                 }
             }
         }
-        CharacterKey { caption: "s"; captionShifted: "S"; symView: "#"; symView2: "^"; accents: "#"; accentsShifted: "#";
+        CharacterKey { caption: "s"; captionShifted: "S"; symView: "#"; symView2: "^"; accents: "#S$"; accentsShifted: "#S$";
             Text {
                 text: showSymbolsOnKey("#");
                 color: Theme.highlightColor;
@@ -297,7 +298,7 @@ KeyboardLayout {
                 }
             }
         }
-        CharacterKey { caption: "m"; captionShifted: "M"; symView: "?"; symView2: "¿"; accents: "^"; accentsShifted: "^";
+        CharacterKey { caption: "m"; captionShifted: "M"; symView: "?"; symView2: "¿"; accents: "^mµ"; accentsShifted: "^Mµ";
             Text {
                 text: showSymbolsOnKey("^");
                 color: Theme.highlightColor;
@@ -373,6 +374,14 @@ KeyboardLayout {
             implicitWidth: punctuationKeyWidth
             fixedWidth: !splitActive
             symView: ":"; symView2: "‰";
+            accents: "`"; accentsShifted: "`";
+            Text {
+                text: showSymbolsOnKey("`");
+                color: Theme.highlightColor;
+                anchors {
+                    horizontalCenter: parent.horizontalCenter
+                }
+            }
         }
 
         BackspaceKey {}

--- a/layouts/sobek_frn_me.qml
+++ b/layouts/sobek_frn_me.qml
@@ -171,7 +171,7 @@ KeyboardLayout {
         }
         CharacterKey {
             caption: "u"; captionShifted: "U"; symView: "7"; symView2: "<"
-            accents: "<uµùúûü"; accentsShifted: "«UµÙÚÛÜ"
+            accents: "ùú<uµûü"; accentsShifted: "ÙÚ«UµÛÜ"
             nativeAccents: "ûùü"; nativeAccentsShifted: "ÛÙÜ";
             Text {
                 text: showSymbolsOnKey("<");
@@ -183,7 +183,7 @@ KeyboardLayout {
         }
         CharacterKey {
             caption: "i"; captionShifted: "I"; symView: "8"; symView2: ">"
-            accents: ">iïîíì"; accentsShifted: "»IÏÌÎÍ"
+            accents: "îï>iíì"; accentsShifted: "ÏÌ»IÎÍ"
             nativeAccents: "îï"; nativeAccentsShifted: "ÎÏ";
             Text {
                 text: showSymbolsOnKey(">");
@@ -226,7 +226,7 @@ KeyboardLayout {
                 }
             }
         }
-        CharacterKey { caption: "s"; captionShifted: "S"; symView: "#"; symView2: "^"; accents: "#S$"; accentsShifted: "#S$";
+        CharacterKey { caption: "s"; captionShifted: "S"; symView: "#"; symView2: "^"; accents: "#s$"; accentsShifted: "#S$";
             Text {
                 text: showSymbolsOnKey("#");
                 color: Theme.highlightColor;


### PR DESCRIPTION
Fix showSymbol of letter 'r' ; place symbols closer to the caption letter in each accents list. I wanted to get the symbols directly selected on long press, but the caption letter is always present in the accents popup (even if not specified) and selected by default.